### PR TITLE
Add tabbed layout and expandable game view

### DIFF
--- a/frontend/src/GachaGame.jsx
+++ b/frontend/src/GachaGame.jsx
@@ -292,7 +292,7 @@ function initialLogic(units) {
   }
 }
 
-export default function GachaGame({ items }) {
+export default function GachaGame({ items, className = 'card', isExpanded = false, onToggleExpand }) {
   const units = useMemo(() => buildUnits(items), [items])
   const enemiesRef = useRef([])
   const shotsRef = useRef([])
@@ -357,11 +357,25 @@ export default function GachaGame({ items }) {
 
   const stats = snapshot.stats
 
+  const rootClassName = ['game-card', className, isExpanded ? 'game-card-expanded' : '']
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <div className="card game-card">
-      <div className="row">
+    <div className={rootClassName}>
+      <div className="row game-header">
         <h3>Crystal Siege 3D</h3>
         <div className="spacer" />
+        {onToggleExpand ? (
+          <button
+            type="button"
+            className="btn secondary game-expand-button"
+            onClick={onToggleExpand}
+            aria-expanded={isExpanded}
+          >
+            {isExpanded ? 'Exit Full View' : 'Expand Arena'}
+          </button>
+        ) : null}
         <div className="row game-buttons">
           <button className="btn secondary" onClick={resetGame}>Reset</button>
           {running ? (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -27,6 +27,42 @@ a { color: var(--accent); text-decoration: none; }
 .spacer { flex: 1; }
 .muted { color: var(--muted); }
 .stack { display: grid; gap: 10px; }
+.tabbed-card { padding: 0; overflow: hidden; display: grid; }
+.tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 18px 18px 12px;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.tab-button {
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(255,255,255,.04);
+  border: 1px solid rgba(255,255,255,.14);
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: .01em;
+  transition: background .2s ease, color .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+.tab-button:hover {
+  color: var(--text);
+  border-color: rgba(255,255,255,.24);
+}
+.tab-button.is-active {
+  color: var(--text);
+  background: linear-gradient(135deg, rgba(106,160,255,.28), rgba(158,106,255,.24));
+  border-color: rgba(158,106,255,.45);
+  box-shadow: 0 12px 26px rgba(0,0,0,.32);
+}
+.tab-button:focus-visible {
+  outline: 2px solid rgba(106,160,255,.8);
+  outline-offset: 2px;
+}
+.tab-content { padding: 18px; }
+.tab-panel { display: grid; gap: 16px; }
 .banner { background: radial-gradient(400px 200px at 20% 0%, rgba(106,160,255,.2), transparent), radial-gradient(400px 200px at 80% 100%, rgba(158,106,255,.2), transparent); padding: 18px; border-radius: var(--radius); border: 1px dashed rgba(255,255,255,.1); }
 .rarity-common { color: #c0cadb; }
 .rarity-rare { color: #70d9ff; }
@@ -232,8 +268,11 @@ a { color: var(--accent); text-decoration: none; }
   45% { opacity: 0; transform: scale(.4) rotate(-10deg); }
 }
 
+.collection-tracker { display: grid; gap: 12px; }
 .game-card { display: grid; gap: 16px; }
-.game-buttons { gap: 8px; }
+.game-header { align-items: center; flex-wrap: wrap; }
+.game-expand-button { white-space: nowrap; }
+.game-buttons { gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 .arena-wrapper {
   position: relative;
   border-radius: 18px;
@@ -333,6 +372,39 @@ a { color: var(--accent); text-decoration: none; }
   gap: 8px;
   font-size: 12px;
   color: rgba(255,255,255,.72);
+}
+.game-expand-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(6,8,14,.72);
+  backdrop-filter: blur(6px);
+  z-index: 870;
+  cursor: zoom-out;
+}
+.game-card-expanded {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(1100px, calc(100% - 48px));
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  z-index: 880;
+  padding: 24px;
+  background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.03));
+  border: 1px solid rgba(255,255,255,.12);
+  box-shadow: 0 40px 80px rgba(0,0,0,.55);
+  border-radius: var(--radius);
+}
+.game-card-expanded .arena-wrapper {
+  min-height: clamp(420px, 70vh, 780px);
+}
+.game-card-expanded .arena-wrapper canvas,
+.game-card-expanded .arena-canvas {
+  height: clamp(420px, 70vh, 780px) !important;
+}
+.game-card-expanded .unit-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- add a tabbed card so Crystal Siege 3D lives on its own tab next to the collection tracker
- wire an expand button and overlay so the arena can pop into a wider view and collapse again (including ESC/backdrop handling)
- introduce supporting layout and styling updates for the tabs and expanded arena state

## Testing
- npm run build *(fails: registry access to @react-three/drei/@react-three/fiber is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1469043d88328a9d461a652ac3e67